### PR TITLE
fix: bump golang.org/x/crypto v0.23.0 → 0.52.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -42,7 +42,7 @@ require (
 	github.com/valyala/fasttemplate v1.2.2 // indirect
 	github.com/wailsapp/go-webview2 v1.0.16 // indirect
 	github.com/wailsapp/mimetype v1.4.1 // indirect
-	golang.org/x/crypto v0.23.0 // indirect
+	golang.org/x/crypto v0.52.0 // indirect
 	golang.org/x/exp v0.0.0-20230522175609-2e198f4a06a1 // indirect
 	golang.org/x/net v0.25.0 // indirect
 	golang.org/x/sys v0.20.0 // indirect


### PR DESCRIPTION
Automated dependency upgrade: bump `golang.org/x/crypto` `v0.23.0` → `0.52.0`.

**Run `go mod tidy` to update go.sum before merging** — go.sum cannot be regenerated through the API.